### PR TITLE
Update references to chatlog -> chatcli

### DIFF
--- a/chatcli_gpt/chatcli.py
+++ b/chatcli_gpt/chatcli.py
@@ -266,7 +266,7 @@ def log(limit, usage, cost, plugins, search_options):
 
     \b
     cp -i .chatcli.log .chatcli.log.bak
-    chatlog convert .chatcli.log.bak > .chatcli.log
+    chatcli convert .chatcli.log.bak > .chatcli.log
     """
 )
 @click.argument("filename", type=click.Path(exists=True))
@@ -428,7 +428,7 @@ def main():
     try:
         cli()
     except FileNotFoundError as error:
-        click.echo(f"{error}: Chatlog not initialized. Run `chatlog init` first.")
+        click.echo(f"{error}: Chatcli not initialized. Run `chatcli init` first.")
         sys.exit(1)
 
 


### PR DESCRIPTION
There are a few references to chatlog in usage, which this updates to reflect the current name and usage.

I noticed these when I went to use it and got confused by the usage, wondering if there was an extra tool called chatlog, before I realized the command it was suggesting was part of chatcli.