### PR TITLE
Fix tests, add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+
+test:
+	poetry run pytest
+
+format:
+	poetry run black .

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -19,13 +19,20 @@ def test_extract_block():
 
 
 def test_simple_code():
-    assert exec_python("print(3 + 4)") == '7'
+    assert exec_python("print(3 + 4)") == result('7')
+
 
 def test_sqrt_example():
-    assert exec_python("import math; math.sqrt(4)") == '2.0'
+    assert exec_python("import math; math.sqrt(4)") == result('2.0')
+
 
 def test_use_defined_function():
-    assert exec_python("def double(x):\n  return 2 * x\ndouble(4)\n") == '8'
+    assert exec_python("def double(x):\n  return 2 * x\ndouble(4)\n") == result('8')
+
 
 def test_recursive_function():
-    assert exec_python("def fact(n):\n if n <= 1:\n  return n\n return fact(n - 1) * n\nfact(6)\n") == '720'
+    assert exec_python("def fact(n):\n if n <= 1:\n  return n\n return fact(n - 1) * n\nfact(6)\n") == result('720')
+
+
+def result(result, error=""):
+    return {"result": result, "error": error}


### PR DESCRIPTION
Currently on `main`, four tests fail, because the format that is returned from the plugin functions has changed without these tests being updated. This PR updates the tests to pass, utilizing a new helper function. It also adds a Makefile which serves as a rudimentary command runner (and form of documentation) for the test and format commands.

I added the format command into the Makefile, but did not run it. It's going to make a reasonable size diff, which should be done independently. I personally feel we should rip that bandaid off, but I'll leave that decision to @cthulahoops .

I'd also like to add a GitHub Action which will run the tests, if that contribution is welcome. This would help prevent further test regressions.